### PR TITLE
Добавить сохранение и восстановление фильтров при обновлении страницы #43

### DIFF
--- a/search-service/frontend/package-lock.json
+++ b/search-service/frontend/package-lock.json
@@ -223,9 +223,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -243,9 +240,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,9 +257,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -283,9 +274,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -303,9 +291,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -323,9 +308,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +732,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -774,9 +753,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -798,9 +774,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -822,9 +795,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/search-service/frontend/src/App.vue
+++ b/search-service/frontend/src/App.vue
@@ -83,7 +83,7 @@ onMounted(() => {
   const urlParams = new URLSearchParams(window.location.search)
   const urlQ = urlParams.get('q')
 
-  useFiltersInstance.restoreFromUrl() // используй переменную из useFilters()
+  useFiltersInstance.restoreFromUrl()
 
   if (urlQ) {
     query.value = urlQ

--- a/search-service/frontend/src/App.vue
+++ b/search-service/frontend/src/App.vue
@@ -13,7 +13,7 @@ const dropdownOpen = ref(false)
 
 const { recentSearches, save: saveRecent } = useRecentSearches()
 const { suggestions, isTyping, onFocus: _onFocus, onInput: _onInput, clear: clearSuggestions } = useSuggestions()
-const { selectedLangs, sortBy, dateFilter, fromDate, toDate, formatDateForQuery } = useFilters()
+const { selectedLangs, sortBy, dateFilter, fromDate, toDate, formatDateForQuery, restoreFromUrl, resetFilters } = useFilters()
 const { query, lastQuery, results, total, resultStatus, inResults, doSearch: _doSearch, clearAll: _clearAll } = useSearch({ isEmbed, saveRecent, formatDateForQuery })
 
 provide('highlight', createHighlighter(lastQuery))
@@ -48,6 +48,9 @@ watch(toDate, (val) => {
 // --- Methods ---
 function doSearch(q) {
   dropdownOpen.value = false
+  if (q !== undefined && q.trim() !== lastQuery.value && inResults.value) {
+    resetFilters()
+  }
   _doSearch(q, { selectedLangs, sortBy, dateFilter, fromDate, toDate })
 }
 
@@ -83,7 +86,7 @@ onMounted(() => {
   const urlParams = new URLSearchParams(window.location.search)
   const urlQ = urlParams.get('q')
 
-  useFiltersInstance.restoreFromUrl()
+  restoreFromUrl()
 
   if (urlQ) {
     query.value = urlQ

--- a/search-service/frontend/src/App.vue
+++ b/search-service/frontend/src/App.vue
@@ -55,6 +55,7 @@ function clearAll() {
   clearSuggestions()
   dropdownOpen.value = false
   _clearAll()
+  resetFilters()
 }
 
 function onFocus() {
@@ -81,15 +82,11 @@ function handleClear() {
 onMounted(() => {
   const urlParams = new URLSearchParams(window.location.search)
   const urlQ = urlParams.get('q')
+
+  useFiltersInstance.restoreFromUrl() // используй переменную из useFilters()
+
   if (urlQ) {
     query.value = urlQ
-
-    selectedLangs.value = urlParams.getAll('lang')
-    sortBy.value = urlParams.get('sort_by') || 'relevance'
-    dateFilter.value = urlParams.get('date_filter') || null
-    fromDate.value = urlParams.get('from_date') || null
-    toDate.value = urlParams.get('to_date') || null
-
     doSearch(urlQ)
   }
 })

--- a/search-service/frontend/src/composables/useFilters.js
+++ b/search-service/frontend/src/composables/useFilters.js
@@ -16,14 +16,31 @@ export function useFilters() {
     }
   }
 
-  /**
-   * Converts yyyy-mm-dd (HTML date input format) to dd-mm-yyyy (API format).
-   */
+  function restoreFromUrl() {
+    const params = new URLSearchParams(window.location.search)
+    selectedLangs.value = params.getAll('lang')
+    sortBy.value = params.get('sort_by') || 'relevance'
+    dateFilter.value = params.get('date_filter') || null
+    fromDate.value = params.get('from_date') || null
+    toDate.value = params.get('to_date') || null
+  }
+
+  function resetFilters() {
+    selectedLangs.value = []
+    sortBy.value = 'relevance'
+    dateFilter.value = null
+    fromDate.value = null
+    toDate.value = null
+  }
+
   function formatDateForQuery(dateStr) {
     if (!dateStr) return null
     const [y, m, d] = dateStr.split('-')
     return `${d}-${m}-${y}`
   }
 
-  return { selectedLangs, sortBy, dateFilter, fromDate, toDate, toggleLang, formatDateForQuery }
+  return {
+    selectedLangs, sortBy, dateFilter, fromDate, toDate,
+    toggleLang, formatDateForQuery, restoreFromUrl, resetFilters
+  }
 }

--- a/search-service/frontend/src/composables/useSearch.js
+++ b/search-service/frontend/src/composables/useSearch.js
@@ -99,9 +99,10 @@ export function useSearch({ isEmbed, saveRecent, formatDateForQuery }) {
     inResults.value = false
     resultStatus.value = 'loading'
 
-    const urlParams = new URLSearchParams(window.location.search)
-    urlParams.delete('q')
-    const qs = urlParams.toString()
+    const newParams = new URLSearchParams()
+    if (isEmbed.value) newParams.set('embed', 'true')
+
+    const qs = newParams.toString()
     window.history.replaceState({}, '', qs ? `?${qs}` : window.location.pathname)
   }
 


### PR DESCRIPTION
Связал состояние фильтров (язык, сортировка, даты) с параметрами URL. Теперь при обновлении страницы (F5) или пересылке ссылки все настройки поиска сохраняются.

**Основные изменения:**
*   **В `useFilters.js`:** добавил функции `restoreFromUrl` для чтения параметров из адресной строки и `resetFilters` для полной очистки состояния.
*   **В `App.vue`:** в хуке `onMounted` теперь первым делом восстанавливаем фильтры из URL. Если в ссылке уже есть поисковый запрос (`q`), поиск запускается автоматически сразу при загрузке.
*   **В `useSearch.js`:** поправил функцию `clearAll`, чтобы при сбросе поиска из URL удалялись вообще все параметры и ссылка становилась «чистой».

**Closes #43**