### PR TITLE
#102: Иcправил предупреждение в логах при поисковом запросе

### DIFF
--- a/search-service/backend/models/schemas.py
+++ b/search-service/backend/models/schemas.py
@@ -18,7 +18,15 @@ class ArticleResult(BaseModel):
     keywords: list[str]
     date: date | None
     lang: str
-    url: HttpUrl
+    url: str
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def validate_url(cls, v: Any) -> str:
+        s = str(v)
+        if s.startswith("/"):
+            return s
+        return str(HttpUrl(s))
 
     @field_validator("date", mode="before")
     @classmethod


### PR DESCRIPTION
`wrap_results_with_click_links` подменяет `url` на относительные `/api/click?...`, а в схеме было `HttpUrl` — при сериализации Pydantic ругался на `str` вместо `HttpUrl`. Теперь пути с `/` (click-обёртка) пропускаем, абсолютные URL по-прежнему проверяем через `HttpUrl`.

Closes #102 